### PR TITLE
UIKit + Threading Decorator

### DIFF
--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		EA007F192B7BB92A0068F486 /* FeedLocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA007F182B7BB92A0068F486 /* FeedLocalizationTests.swift */; };
 		EA007F1B2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA007F1A2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift */; };
+		EA007F1D2B7BD0800068F486 /* WeakRefVirtualProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA007F1C2B7BD0800068F486 /* WeakRefVirtualProxy.swift */; };
+		EA007F1F2B7BD0BD0068F486 /* FeedImageDataLoaderPresentationAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA007F1E2B7BD0BD0068F486 /* FeedImageDataLoaderPresentationAdapter.swift */; };
+		EA007F212B7BD0F50068F486 /* FeedViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA007F202B7BD0F50068F486 /* FeedViewAdapter.swift */; };
+		EA007F232B7BD1230068F486 /* FeedLoaderPresentationAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA007F222B7BD1230068F486 /* FeedLoaderPresentationAdapter.swift */; };
 		EA04C7142B7BAD8400591C9E /* FeedImageCell+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA04C7132B7BAD8400591C9E /* FeedImageCell+TestHelpers.swift */; };
 		EA04C7162B7BADCF00591C9E /* FeedViewControllerTests+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA04C7152B7BADCF00591C9E /* FeedViewControllerTests+Assertions.swift */; };
 		EA04C7182B7BAE3D00591C9E /* FeedViewControllerTests+LoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA04C7172B7BAE3D00591C9E /* FeedViewControllerTests+LoaderSpy.swift */; };
@@ -157,6 +161,10 @@
 /* Begin PBXFileReference section */
 		EA007F182B7BB92A0068F486 /* FeedLocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLocalizationTests.swift; sourceTree = "<group>"; };
 		EA007F1A2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainQueueDispatchDecorator.swift; sourceTree = "<group>"; };
+		EA007F1C2B7BD0800068F486 /* WeakRefVirtualProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakRefVirtualProxy.swift; sourceTree = "<group>"; };
+		EA007F1E2B7BD0BD0068F486 /* FeedImageDataLoaderPresentationAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderPresentationAdapter.swift; sourceTree = "<group>"; };
+		EA007F202B7BD0F50068F486 /* FeedViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewAdapter.swift; sourceTree = "<group>"; };
+		EA007F222B7BD1230068F486 /* FeedLoaderPresentationAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderPresentationAdapter.swift; sourceTree = "<group>"; };
 		EA04C7132B7BAD8400591C9E /* FeedImageCell+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedImageCell+TestHelpers.swift"; sourceTree = "<group>"; };
 		EA04C7152B7BADCF00591C9E /* FeedViewControllerTests+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedViewControllerTests+Assertions.swift"; sourceTree = "<group>"; };
 		EA04C7172B7BAE3D00591C9E /* FeedViewControllerTests+LoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedViewControllerTests+LoaderSpy.swift"; sourceTree = "<group>"; };
@@ -423,6 +431,10 @@
 			isa = PBXGroup;
 			children = (
 				EA66D06F2B693F76002B11ED /* FeedUIComposer.swift */,
+				EA007F222B7BD1230068F486 /* FeedLoaderPresentationAdapter.swift */,
+				EA007F1C2B7BD0800068F486 /* WeakRefVirtualProxy.swift */,
+				EA007F202B7BD0F50068F486 /* FeedViewAdapter.swift */,
+				EA007F1E2B7BD0BD0068F486 /* FeedImageDataLoaderPresentationAdapter.swift */,
 				EA007F1A2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift */,
 			);
 			path = Composers;
@@ -851,11 +863,15 @@
 				EAA7CFAA2B73002600EDA29E /* FeedLoadingViewModel.swift in Sources */,
 				EA3745572B66E5A30086FF35 /* UIView+Shimmering.swift in Sources */,
 				EAA7CFA82B72731400EDA29E /* FeedImagePresenter.swift in Sources */,
+				EA007F1D2B7BD0800068F486 /* WeakRefVirtualProxy.swift in Sources */,
 				EA9A05A72B7A7E7300BE9831 /* UIImageView+Animations.swift in Sources */,
 				EA007F1B2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift in Sources */,
 				EAA6A9282B5EBCF60022A99E /* FeedViewController.swift in Sources */,
 				EAA6A92F2B614C720022A99E /* FeedImageCell.swift in Sources */,
+				EA007F232B7BD1230068F486 /* FeedLoaderPresentationAdapter.swift in Sources */,
+				EA007F1F2B7BD0BD0068F486 /* FeedImageDataLoaderPresentationAdapter.swift in Sources */,
 				EAE70DE42B6B483A0075F873 /* FeedImageViewModel.swift in Sources */,
+				EA007F212B7BD0F50068F486 /* FeedViewAdapter.swift in Sources */,
 				EA66D06D2B693BB1002B11ED /* FeedImageCellController.swift in Sources */,
 				EA66D0702B693F76002B11ED /* FeedUIComposer.swift in Sources */,
 			);

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		EA007F192B7BB92A0068F486 /* FeedLocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA007F182B7BB92A0068F486 /* FeedLocalizationTests.swift */; };
+		EA007F1B2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA007F1A2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift */; };
 		EA04C7142B7BAD8400591C9E /* FeedImageCell+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA04C7132B7BAD8400591C9E /* FeedImageCell+TestHelpers.swift */; };
 		EA04C7162B7BADCF00591C9E /* FeedViewControllerTests+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA04C7152B7BADCF00591C9E /* FeedViewControllerTests+Assertions.swift */; };
 		EA04C7182B7BAE3D00591C9E /* FeedViewControllerTests+LoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA04C7172B7BAE3D00591C9E /* FeedViewControllerTests+LoaderSpy.swift */; };
@@ -155,6 +156,7 @@
 
 /* Begin PBXFileReference section */
 		EA007F182B7BB92A0068F486 /* FeedLocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLocalizationTests.swift; sourceTree = "<group>"; };
+		EA007F1A2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainQueueDispatchDecorator.swift; sourceTree = "<group>"; };
 		EA04C7132B7BAD8400591C9E /* FeedImageCell+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedImageCell+TestHelpers.swift"; sourceTree = "<group>"; };
 		EA04C7152B7BADCF00591C9E /* FeedViewControllerTests+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedViewControllerTests+Assertions.swift"; sourceTree = "<group>"; };
 		EA04C7172B7BAE3D00591C9E /* FeedViewControllerTests+LoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedViewControllerTests+LoaderSpy.swift"; sourceTree = "<group>"; };
@@ -421,6 +423,7 @@
 			isa = PBXGroup;
 			children = (
 				EA66D06F2B693F76002B11ED /* FeedUIComposer.swift */,
+				EA007F1A2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift */,
 			);
 			path = Composers;
 			sourceTree = "<group>";
@@ -849,6 +852,7 @@
 				EA3745572B66E5A30086FF35 /* UIView+Shimmering.swift in Sources */,
 				EAA7CFA82B72731400EDA29E /* FeedImagePresenter.swift in Sources */,
 				EA9A05A72B7A7E7300BE9831 /* UIImageView+Animations.swift in Sources */,
+				EA007F1B2B7BD01A0068F486 /* MainQueueDispatchDecorator.swift in Sources */,
 				EAA6A9282B5EBCF60022A99E /* FeedViewController.swift in Sources */,
 				EAA6A92F2B614C720022A99E /* FeedImageCell.swift in Sources */,
 				EAE70DE42B6B483A0075F873 /* FeedImageViewModel.swift in Sources */,

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedImageDataLoaderPresentationAdapter.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedImageDataLoaderPresentationAdapter.swift
@@ -1,0 +1,48 @@
+//
+//  FeedImageDataLoaderPresentationAdapter.swift
+//  EssentialFeediOS
+//
+//  Created by Nikhil Menon on 2/13/24.
+//
+
+import EssentialFeed
+
+final class FeedImageDataLoaderPresentationAdapter<View: FeedImageView, Image>: FeedImageCellControllerDelegate where Image == View.Image {
+    private let model: FeedImage
+    private let imageLoader: FeedImageDataLoader
+    private var task: FeedImageDataLoaderTask?
+    
+    var presenter: FeedImagePresenter<View, Image>?
+    
+    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
+        self.model = model
+        self.imageLoader = imageLoader
+    }
+    
+    func didRequestImage() {
+        presenter?.didStartLoadingImageData(for: model)
+        let model = self.model
+        task = imageLoader.loadImageData(from: model.url) { [weak self] result in
+            switch result {
+            case let .success(data):
+                self?.presenter?.didFinishLoadingImageData(with: data, for: model)
+            case let .failure(error):
+                self?.presenter?.didFinishLoadingImageData(with: error, for: model)
+            }
+        }
+    }
+    
+    func didCancelImageRequest() {
+        task?.cancel()
+        task = nil
+    }
+    
+    private func handle(_ result: FeedImageDataLoader.Result) {
+        switch result {
+        case let .success(data):
+            self.presenter?.didFinishLoadingImageData(with: data, for: model)
+        case let .failure(error):
+            self.presenter?.didFinishLoadingImageData(with: error, for: model)
+        }
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedLoaderPresentationAdapter.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedLoaderPresentationAdapter.swift
@@ -1,0 +1,30 @@
+//
+//  FeedLoaderPresentationAdapter.swift
+//  EssentialFeediOS
+//
+//  Created by Nikhil Menon on 2/13/24.
+//
+
+import EssentialFeed
+
+final class FeedLoaderPresentationAdapter: FeedViewControllerDelegate {
+    private let feedLoader: FeedLoader
+    var presenter: FeedPresenter?
+    
+    init(feedLoader: FeedLoader) {
+        self.feedLoader = feedLoader
+    }
+    
+    func didRequestFeedRefresh() {
+        presenter?.didStartLoadingFeed()
+        feedLoader.load { [weak self] result in
+            switch result {
+            case let .success(feed):
+                self?.presenter?.didFinishLoadingFeed(with: feed)
+            case let .failure(error):
+                self?.presenter?.didFinishLoadingFeed(with: error)
+            }
+            
+        }
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -12,8 +12,7 @@ public final class FeedUIComposer {
     private init() { }
     
     public static func feedComposedWith(feedLoader: FeedLoader, imageLoader: FeedImageDataLoader) -> FeedViewController {
-        let presentationAdapter = FeedLoaderPresentationAdapter(feedLoader: feedLoader)
-        
+        let presentationAdapter = FeedLoaderPresentationAdapter(feedLoader: MainQueueDispatchDecorator(decoratee: feedLoader))
         let feedController = FeedViewController.makeWith(delegate: presentationAdapter, title: FeedPresenter.title)
         
         let proxyView = WeakRefVirtualProxy(feedController)
@@ -25,6 +24,26 @@ public final class FeedUIComposer {
         presentationAdapter.presenter = presenter
         
         return feedController
+    }
+}
+
+private final class MainQueueDispatchDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    
+    init(decoratee: FeedLoader) {
+        self.decoratee = decoratee
+    }
+    
+    func load(completion: @escaping (Result<[EssentialFeed.FeedImage], Error>) -> Void) {
+        decoratee.load { result in
+            if Thread.isMainThread {
+                completion(result)
+            } else  {
+                DispatchQueue.main.async {
+                    completion(result)
+                }
+            }
+        }
     }
 }
 

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -27,38 +27,6 @@ public final class FeedUIComposer {
     }
 }
 
-private final class MainQueueDispatchDecorator<T> {
-    private let decoratee: T
-    
-    init(decoratee: T) {
-        self.decoratee = decoratee
-    }
-    
-    func dispatch(completion: @escaping () -> Void) {
-        guard Thread.isMainThread else {
-            return DispatchQueue.main.async(execute: completion)
-        }
-        
-        completion()
-    }
-}
-
-extension MainQueueDispatchDecorator: FeedLoader where T == FeedLoader {
-    func load(completion: @escaping (Result<[EssentialFeed.FeedImage], Error>) -> Void) {
-        decoratee.load { [weak self] result in
-            self?.dispatch { completion(result) }
-        }
-    }
-}
-
-extension MainQueueDispatchDecorator: FeedImageDataLoader where T == FeedImageDataLoader {
-    func loadImageData(from url: URL, completion: @escaping ((Result<Data, Error>) -> Void)) -> FeedImageDataLoaderTask {
-        decoratee.loadImageData(from: url) { [weak self] result in
-            self?.dispatch { completion(result) }
-        }
-    }
-}
-
 fileprivate extension FeedViewController {
     static func makeWith(delegate: FeedViewControllerDelegate, title: String) -> FeedViewController {
         let bundle = Bundle(for: FeedViewController.self)

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -14,7 +14,8 @@ public final class FeedUIComposer {
     public static func feedComposedWith(feedLoader: FeedLoader, imageLoader: FeedImageDataLoader) -> FeedViewController {
         let presentationAdapter = FeedLoaderPresentationAdapter(feedLoader: feedLoader)
         
-        let feedController = FeedViewController.makeWith(delegate: presentationAdapter, title: "My Feed")
+        let feedController = FeedViewController.makeWith(delegate: presentationAdapter, title: FeedPresenter.title)
+        
         let proxyView = WeakRefVirtualProxy(feedController)
         let presenter = FeedPresenter(
             feedView: FeedViewAdapter(controller: feedController, imageLoader: imageLoader),

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -13,7 +13,7 @@ public final class FeedUIComposer {
     
     public static func feedComposedWith(feedLoader: FeedLoader, imageLoader: FeedImageDataLoader) -> FeedViewController {
         let presentationAdapter = FeedLoaderPresentationAdapter(feedLoader: MainQueueDispatchDecorator(decoratee: feedLoader))
-        let feedController = FeedViewController.makeWith(delegate: presentationAdapter, title: FeedPresenter.title)
+        let feedController = makeFeedViewController(delegate: presentationAdapter, title: FeedPresenter.title)
         
         let proxyView = WeakRefVirtualProxy(feedController)
         let presenter = FeedPresenter(
@@ -25,117 +25,13 @@ public final class FeedUIComposer {
         
         return feedController
     }
-}
-
-fileprivate extension FeedViewController {
-    static func makeWith(delegate: FeedViewControllerDelegate, title: String) -> FeedViewController {
+    
+    private static func makeFeedViewController(delegate: FeedViewControllerDelegate, title: String) -> FeedViewController {
         let bundle = Bundle(for: FeedViewController.self)
         let storyboard = UIStoryboard(name: "Feed", bundle: bundle)
         let feedController = storyboard.instantiateInitialViewController() as! FeedViewController
         feedController.delegate = delegate
         feedController.title = title
         return feedController
-    }
-}
-
-private final class WeakRefVirtualProxy<T: AnyObject> {
-    private weak var object: T?
-    
-    init(_ object: T) {
-        self.object = object
-    }
-}
-
-extension WeakRefVirtualProxy: FeedLoadingView where T: FeedLoadingView {
-    func display(_ viewModel: FeedLoadingViewModel) {
-        object?.display(viewModel)
-    }
-}
-
-extension WeakRefVirtualProxy: FeedImageView where T: FeedImageView, T.Image == UIImage {
-    func display(_ viewModel: FeedImageViewModel<UIImage>) {
-        object?.display(viewModel)
-    }
-}
-
-private final class FeedViewAdapter: FeedView {
-    private weak var controller: FeedViewController?
-    private let imageLoader: FeedImageDataLoader
-    
-    init(controller: FeedViewController?, imageLoader: FeedImageDataLoader) {
-        self.controller = controller
-        self.imageLoader = imageLoader
-    }
-    
-    func display(_ viewModel: FeedViewModel) {
-        controller?.tableModel = viewModel.feed.map { model in
-            let adapter = FeedImageDataLoaderPresentationAdapter<WeakRefVirtualProxy<FeedImageCellController>, UIImage>(model: model, imageLoader: imageLoader)
-            let view = FeedImageCellController(delegate: adapter)
-            let weakView = WeakRefVirtualProxy(view)
-            adapter.presenter = FeedImagePresenter(view: weakView, imageTransformer: UIImage.init)
-            return view
-        }
-    }
-}
-
-private final class FeedImageDataLoaderPresentationAdapter<View: FeedImageView, Image>: FeedImageCellControllerDelegate where Image == View.Image {
-    private let model: FeedImage
-    private let imageLoader: FeedImageDataLoader
-    private var task: FeedImageDataLoaderTask?
-    
-    var presenter: FeedImagePresenter<View, Image>?
-    
-    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
-        self.model = model
-        self.imageLoader = imageLoader
-    }
-    
-    func didRequestImage() {
-        presenter?.didStartLoadingImageData(for: model)
-        let model = self.model
-        task = imageLoader.loadImageData(from: model.url) { [weak self] result in
-            switch result {
-            case let .success(data):
-                self?.presenter?.didFinishLoadingImageData(with: data, for: model)
-            case let .failure(error):
-                self?.presenter?.didFinishLoadingImageData(with: error, for: model)
-            }
-        }
-    }
-    
-    func didCancelImageRequest() {
-        task?.cancel()
-        task = nil
-    }
-    
-    private func handle(_ result: FeedImageDataLoader.Result) {
-        switch result {
-        case let .success(data):
-            self.presenter?.didFinishLoadingImageData(with: data, for: model)
-        case let .failure(error):
-            self.presenter?.didFinishLoadingImageData(with: error, for: model)
-        }
-    }
-}
-
-private final class FeedLoaderPresentationAdapter: FeedViewControllerDelegate {
-    private let feedLoader: FeedLoader
-    var presenter: FeedPresenter?
-    
-    init(feedLoader: FeedLoader) {
-        self.feedLoader = feedLoader
-    }
-    
-    func didRequestFeedRefresh() {
-        presenter?.didStartLoadingFeed()
-        feedLoader.load { [weak self] result in
-            switch result {
-            case let .success(feed):
-                self?.presenter?.didFinishLoadingFeed(with: feed)
-            case let .failure(error):
-                self?.presenter?.didFinishLoadingFeed(with: error)
-            }
-            
-        }
     }
 }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -27,22 +27,26 @@ public final class FeedUIComposer {
     }
 }
 
-private final class MainQueueDispatchDecorator: FeedLoader {
-    private let decoratee: FeedLoader
+private final class MainQueueDispatchDecorator<T> {
+    private let decoratee: T
     
-    init(decoratee: FeedLoader) {
+    init(decoratee: T) {
         self.decoratee = decoratee
     }
     
+    func dispatch(completion: @escaping () -> Void) {
+        guard Thread.isMainThread else {
+            return DispatchQueue.main.async(execute: completion)
+        }
+        
+        completion()
+    }
+}
+
+extension MainQueueDispatchDecorator: FeedLoader where T == FeedLoader {
     func load(completion: @escaping (Result<[EssentialFeed.FeedImage], Error>) -> Void) {
-        decoratee.load { result in
-            if Thread.isMainThread {
-                completion(result)
-            } else  {
-                DispatchQueue.main.async {
-                    completion(result)
-                }
-            }
+        decoratee.load { [weak self] result in
+            self?.dispatch { completion(result) }
         }
     }
 }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedViewAdapter.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/FeedViewAdapter.swift
@@ -1,0 +1,28 @@
+//
+//  FeedViewAdapter.swift
+//  EssentialFeediOS
+//
+//  Created by Nikhil Menon on 2/13/24.
+//
+
+import UIKit
+
+final class FeedViewAdapter: FeedView {
+    private weak var controller: FeedViewController?
+    private let imageLoader: FeedImageDataLoader
+    
+    init(controller: FeedViewController?, imageLoader: FeedImageDataLoader) {
+        self.controller = controller
+        self.imageLoader = imageLoader
+    }
+    
+    func display(_ viewModel: FeedViewModel) {
+        controller?.tableModel = viewModel.feed.map { model in
+            let adapter = FeedImageDataLoaderPresentationAdapter<WeakRefVirtualProxy<FeedImageCellController>, UIImage>(model: model, imageLoader: imageLoader)
+            let view = FeedImageCellController(delegate: adapter)
+            let weakView = WeakRefVirtualProxy(view)
+            adapter.presenter = FeedImagePresenter(view: weakView, imageTransformer: UIImage.init)
+            return view
+        }
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/MainQueueDispatchDecorator.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/MainQueueDispatchDecorator.swift
@@ -1,0 +1,40 @@
+//
+//  MainQueueDispatchDecorator.swift
+//  EssentialFeediOS
+//
+//  Created by Nikhil Menon on 2/13/24.
+//
+
+import EssentialFeed
+
+final class MainQueueDispatchDecorator<T> {
+    private let decoratee: T
+    
+    init(decoratee: T) {
+        self.decoratee = decoratee
+    }
+    
+    func dispatch(completion: @escaping () -> Void) {
+        guard Thread.isMainThread else {
+            return DispatchQueue.main.async(execute: completion)
+        }
+        
+        completion()
+    }
+}
+
+extension MainQueueDispatchDecorator: FeedLoader where T == FeedLoader {
+    func load(completion: @escaping (Result<[EssentialFeed.FeedImage], Error>) -> Void) {
+        decoratee.load { [weak self] result in
+            self?.dispatch { completion(result) }
+        }
+    }
+}
+
+extension MainQueueDispatchDecorator: FeedImageDataLoader where T == FeedImageDataLoader {
+    func loadImageData(from url: URL, completion: @escaping ((Result<Data, Error>) -> Void)) -> FeedImageDataLoaderTask {
+        decoratee.loadImageData(from: url) { [weak self] result in
+            self?.dispatch { completion(result) }
+        }
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Composers/WeakRefVirtualProxy.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Composers/WeakRefVirtualProxy.swift
@@ -1,0 +1,29 @@
+//
+//  WeakRefVirtualProxy.swift
+//  EssentialFeediOS
+//
+//  Created by Nikhil Menon on 2/13/24.
+//
+
+import EssentialFeed
+import UIKit
+
+final class WeakRefVirtualProxy<T: AnyObject> {
+    private weak var object: T?
+    
+    init(_ object: T) {
+        self.object = object
+    }
+}
+
+extension WeakRefVirtualProxy: FeedLoadingView where T: FeedLoadingView {
+    func display(_ viewModel: FeedLoadingViewModel) {
+        object?.display(viewModel)
+    }
+}
+
+extension WeakRefVirtualProxy: FeedImageView where T: FeedImageView, T.Image == UIImage {
+    func display(_ viewModel: FeedImageViewModel<UIImage>) {
+        object?.display(viewModel)
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -18,7 +18,15 @@ public class FeedViewController: UITableViewController, UITableViewDataSourcePre
     private var onViewIsAppearing: ((FeedViewController) -> Void)?
     
     internal var tableModel = [FeedImageCellController]() {
-        didSet { tableView.reloadData() }
+        didSet {
+            if Thread.isMainThread {
+                tableView.reloadData()
+            } else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.tableView.reloadData()
+                }
+            }
+        }
     }
     
     public override func viewDidLoad() {
@@ -37,6 +45,7 @@ public class FeedViewController: UITableViewController, UITableViewDataSourcePre
     }
     
     func display(_ viewModel: FeedLoadingViewModel) {
+        guard Thread.isMainThread else { return DispatchQueue.main.async { [weak self] in self?.display(viewModel) }}
         if viewModel.isLoading {
             refreshControl?.beginRefreshing()
         } else {

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -18,15 +18,7 @@ public class FeedViewController: UITableViewController, UITableViewDataSourcePre
     private var onViewIsAppearing: ((FeedViewController) -> Void)?
     
     internal var tableModel = [FeedImageCellController]() {
-        didSet {
-            if Thread.isMainThread {
-                tableView.reloadData()
-            } else {
-                DispatchQueue.main.async { [weak self] in
-                    self?.tableView.reloadData()
-                }
-            }
-        }
+        didSet { tableView.reloadData() }
     }
     
     public override func viewDidLoad() {
@@ -45,7 +37,6 @@ public class FeedViewController: UITableViewController, UITableViewDataSourcePre
     }
     
     func display(_ viewModel: FeedLoadingViewModel) {
-        guard Thread.isMainThread else { return DispatchQueue.main.async { [weak self] in self?.display(viewModel) }}
         if viewModel.isLoading {
             refreshControl?.beginRefreshing()
         } else {

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Feed Presentation/FeedPresenter.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Feed Presentation/FeedPresenter.swift
@@ -30,27 +30,15 @@ final class FeedPresenter {
     }
     
     func didStartLoadingFeed() {
-        guard Thread.isMainThread else {
-            return DispatchQueue.main.async { [weak self] in self?.didStartLoadingFeed() }
-        }
-        
         loadingView.display(FeedLoadingViewModel(isLoading: true))
     }
     
     func didFinishLoadingFeed(with feed: [FeedImage]) {
-        guard Thread.isMainThread else {
-            return DispatchQueue.main.async { [weak self] in self?.didFinishLoadingFeed(with: feed) }
-        }
-        
         feedView.display(FeedViewModel(feed: feed))
         loadingView.display(FeedLoadingViewModel(isLoading: false))
     }
     
     func didFinishLoadingFeed(with error: Error) {
-        guard Thread.isMainThread else {
-            return DispatchQueue.main.async { [weak self] in self?.didFinishLoadingFeed(with: error) }
-        }
-        
         loadingView.display(FeedLoadingViewModel(isLoading: false))
     }
 }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Feed Presentation/FeedPresenter.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Feed Presentation/FeedPresenter.swift
@@ -28,15 +28,27 @@ final class FeedPresenter {
     }
     
     func didStartLoadingFeed() {
+        guard Thread.isMainThread else {
+            return DispatchQueue.main.async { [weak self] in self?.didStartLoadingFeed() }
+        }
+        
         loadingView.display(FeedLoadingViewModel(isLoading: true))
     }
     
     func didFinishLoadingFeed(with feed: [FeedImage]) {
+        guard Thread.isMainThread else {
+            return DispatchQueue.main.async { [weak self] in self?.didFinishLoadingFeed(with: feed) }
+        }
+        
         feedView.display(FeedViewModel(feed: feed))
         loadingView.display(FeedLoadingViewModel(isLoading: false))
     }
     
     func didFinishLoadingFeed(with error: Error) {
+        guard Thread.isMainThread else {
+            return DispatchQueue.main.async { [weak self] in self?.didFinishLoadingFeed(with: error) }
+        }
+        
         loadingView.display(FeedLoadingViewModel(isLoading: false))
     }
 }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Feed Presentation/FeedPresenter.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Feed Presentation/FeedPresenter.swift
@@ -20,7 +20,9 @@ final class FeedPresenter {
     private let feedView: FeedView
     private let loadingView: FeedLoadingView
     
-    static var title: String { NSLocalizedString("FEED_VIEW_TITLE", comment: "Title for the feed view") }
+    static var title: String {
+        NSLocalizedString("FEED_VIEW_TITLE", tableName: "Feed", bundle: Bundle(for: FeedPresenter.self), comment: "Title for the feed view")
+    }
     
     init(feedView: FeedView, loadingView: FeedLoadingView) {
         self.feedView = feedView

--- a/EssentialFeed/EssentialFeediOSTests/FeedUI/FeedUIIntegrationTests.swift
+++ b/EssentialFeed/EssentialFeediOSTests/FeedUI/FeedUIIntegrationTests.swift
@@ -292,6 +292,19 @@ final class FeedUIIntegrationTests: XCTestCase {
         XCTAssertEqual(newView.renderedImage, imageData)
     }
     
+    func test_loadFeedCompletion_dispatchesFromBackgroundToMainThread() {
+        let (sut, loader) = makeSUT()
+        sut.loadViewIfNeeded()
+        
+        let exp = expectation(description: "Wait for background queue")
+        DispatchQueue.global().async {
+            loader.completeFeedLoading(at: 0)
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {

--- a/EssentialFeed/EssentialFeediOSTests/FeedUI/FeedUIIntegrationTests.swift
+++ b/EssentialFeed/EssentialFeediOSTests/FeedUI/FeedUIIntegrationTests.swift
@@ -305,6 +305,22 @@ final class FeedUIIntegrationTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
     
+    func test_loadImageDataCompletion_dispatchesFromBackgroundToMainThread() {
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage()])
+        _ = sut.simulateFeedImageViewVisible(at: 0)
+        
+        let exp = expectation(description: "Wait for background queue")
+        DispatchQueue.global().async {
+            loader.completeImageLoading(with: self.anyImageData(), at: 0)
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {


### PR DESCRIPTION
## Key Takeaways
- **Threading is an implementation detail** that is required by UIKit. You want to hide this detail from client components. Not all UI frameworks may need it if they are thread-safe or if dependencies are guaranteed to use the main thread.
- Presentation layer should stay platform-agnostic. Threading may be required for UIKit but maybe not for other UI frameworks. Don't put thread details here.
- Composition layer knows about *all* components and dependencies. Great place to place threading code logic. Consider a case where FeedLoader cache immediately returns a value; threading is not necessary here, proving importance of placing threading in a layer that knows about all components.
- **Dectorator** pattern is used to add behavior to an existing instance. Different from Proxy, which is used to decouple objects and control access or references.