### PR TITLE
Fix potential crash on didEndDisplayingCell

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		EABF5D6C2BFF761500B5D169 /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EABF5D692BFF761500B5D169 /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EABF5D6D2BFF761500B5D169 /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF5D6A2BFF761500B5D169 /* EssentialFeediOS.framework */; };
 		EABF5D6E2BFF761500B5D169 /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EABF5D6A2BFF761500B5D169 /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		EAC008C62C236BA40035065E /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC008C52C236BA40035065E /* UIView+TestHelpers.swift */; };
 		EAC2A9F12C11DA170040255A /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC2A9F02C11DA170040255A /* FeedLoaderCacheDecoratorTests.swift */; };
 		EACAFE472C21BBAE008C09BF /* HTTPClientStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACAFE462C21BBAE008C09BF /* HTTPClientStub.swift */; };
 		EACAFE492C21BBE7008C09BF /* InMemoryFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACAFE482C21BBE7008C09BF /* InMemoryFeedStore.swift */; };
@@ -120,6 +121,7 @@
 		EAB40FF42C133F2900019F5B /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
 		EABF5D692BFF761500B5D169 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EABF5D6A2BFF761500B5D169 /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EAC008C52C236BA40035065E /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 		EAC2A9F02C11DA170040255A /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		EACAFE462C21BBAE008C09BF /* HTTPClientStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientStub.swift; sourceTree = "<group>"; };
 		EACAFE482C21BBE7008C09BF /* InMemoryFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryFeedStore.swift; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 				EAB40FF22C133E4400019F5B /* FeedImageDataLoaderSpy.swift */,
 				EA0C47812C11DBD0005514E5 /* FeedLoaderStub.swift */,
 				EACAFE462C21BBAE008C09BF /* HTTPClientStub.swift */,
+				EAC008C52C236BA40035065E /* UIView+TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -378,6 +381,7 @@
 				EA90D4EB2C205B3500864028 /* UIRefreshControl+TestHelpers.swift in Sources */,
 				EACAFE472C21BBAE008C09BF /* HTTPClientStub.swift in Sources */,
 				EA1FA6492C10A73E006244A5 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
+				EAC008C62C236BA40035065E /* UIView+TestHelpers.swift in Sources */,
 				EA90D4EC2C205B3500864028 /* FeedViewController+TestHelpers.swift in Sources */,
 				EA90D4E52C205B3500864028 /* UIImage+TestHelpers.swift in Sources */,
 				EA90D4F12C205E6600864028 /* FeedAcceptanceTests.swift in Sources */,

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -52,6 +52,20 @@ final class FeedUIIntegrationTests: XCTestCase {
         XCTAssertFalse(sut.isShowingLoadingIndicator, "Expected no loading indicator once user initiated loading is completed with error")
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+    }
+    
     func test_loadFeedCompletion_rendersSuccessfullyLoadedFeed() {
         let image0 = makeImage(description: "a description", location: "a location")
         let image1 = makeImage(description: nil, location: "another location")

--- a/EssentialApp/EssentialAppTests/Helpers/FeedViewController+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedViewController+TestHelpers.swift
@@ -58,6 +58,8 @@ extension FeedViewController {
     
     func simulateUserInitiatedFeedReload() {
         refreshControl?.simulatePullToRefresh()
+        tableView.layoutIfNeeded()
+        RunLoop.current.run(until: .now)
     }
     
     var errorMessage: String? {

--- a/EssentialApp/EssentialAppTests/Helpers/FeedViewController+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedViewController+TestHelpers.swift
@@ -58,8 +58,6 @@ extension FeedViewController {
     
     func simulateUserInitiatedFeedReload() {
         refreshControl?.simulatePullToRefresh()
-        tableView.layoutIfNeeded()
-        RunLoop.current.run(until: .now)
     }
     
     var errorMessage: String? {

--- a/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
@@ -11,6 +11,7 @@ import XCTest
 
 extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.enforceLayoutCycle()
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+TestHelpers.swift
+//  EssentialAppTests
+//
+//  Created by Nikhil Menon on 6/19/24.
+//
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: .now)
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -23,6 +23,8 @@ public class FeedViewController: UITableViewController, UITableViewDataSourcePre
         didSet { tableView.reloadData() }
     }
     
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -45,6 +47,7 @@ public class FeedViewController: UITableViewController, UITableViewDataSourcePre
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -70,7 +73,7 @@ public class FeedViewController: UITableViewController, UITableViewDataSourcePre
     }
     
     public override func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        tableModel[indexPath.row].cancelLoad()
+        cancelCellControllerLoad(forRowAt: indexPath)
     }
     
     public func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
@@ -84,10 +87,13 @@ public class FeedViewController: UITableViewController, UITableViewDataSourcePre
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller =  tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }


### PR DESCRIPTION
# Problem
Given a user has a feed
When user reloads
And renders a new empty feed
Then the app will app will crash

# Cause

When we do a `tableView.reloadData()` call, the `cellControllers` property is updated in our FeedViewController.
`reloadData()` triggers the `tableView(_:didEndDisplaying:)` method, and this method uses the `cellControllers` array to find and cancel any existing preloading.

The problem though is that we will have set the `cellControllers` property to empty, when the delegate method is wanting to refer to the original array of loaded cells to cancel.

# Solution

Create a new private property on `FeedViewController` that maintains the original list of new loading cellControllers.
Whenever we want to cancel loading of the cells, we use this property to access the old cells that are attempting to load their images.

____

# Takeaways

For performance reasons, UIKit may not immediately re-render a tableview. This can cause some tests to inaccurately reflect state. For that reason, you will have to force an update on your tableviews when you augment state:

```swift
tableView.layoutIfNeeded() // Force an update
RunLoop.current.run(Date()) // Do this to prevent leaks between tests.
```
